### PR TITLE
Add basic ML recommendation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ The Tour Plan Management System is a web and mobile application designed to stre
 - *Database*: Google Firebase
 - *Authentication*: Firebase Authentication
 
+## Setup
+Install dependencies before starting the backend server:
+
+```bash
+cd backend/tourio
+npm install --ignore-scripts
+```
+
+Then run the development server with:
+
+```bash
+npm run dev
+```
+
 
 
 ## Repository URL

--- a/backend/tourio/app.js
+++ b/backend/tourio/app.js
@@ -11,6 +11,7 @@ const addTourRequestRoutes = require('./src/routes/addTourRequestRoutes');
 const dialogflowRoutes = require('./src/routes/dialogflowRoutes');
 const tourFeedbackRoutes = require('./src/routes/tourFeedbackRoutes');
 const getTourFeedbackRoutes = require('./src/routes/getTourFeedbackRoutes')
+const mlRoutes = require('./src/routes/mlRoutes');
 
 const app = express();
 
@@ -33,6 +34,7 @@ app.use('/api/addtourrequest', addTourRequestRoutes);
 app.use('/api/dialogflow', dialogflowRoutes);
 app.use('/api/tourfeedback', tourFeedbackRoutes);
 app.use('/api/gettourfeedbacks', getTourFeedbackRoutes);
+app.use('/api/ml', mlRoutes);
 
 
 

--- a/backend/tourio/package-lock.json
+++ b/backend/tourio/package-lock.json
@@ -14,6 +14,7 @@
         "express": "^5.1.0",
         "firebase-admin": "^13.3.0",
         "leaflet": "^1.9.4",
+        "ml-knn": "^3.0.0",
         "ngrok": "^5.0.0-beta.2",
         "react-leaflet": "^5.0.0",
         "stripe": "^18.1.0"
@@ -2285,6 +2286,21 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/ml-distance-euclidean": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ml-distance-euclidean/-/ml-distance-euclidean-2.0.0.tgz",
+      "integrity": "sha512-yC9/2o8QF0A3m/0IXqCTXCzz2pNEzvmcE/9HFKOZGnTjatvBbsn4lWYJkxENkA4Ug2fnYl7PXQxnPi21sgMy/Q==",
+      "license": "MIT"
+    },
+    "node_modules/ml-knn": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ml-knn/-/ml-knn-3.0.0.tgz",
+      "integrity": "sha512-w7Jig4vW09OYMurlIRRJj8yL2O/835QJpxup+yW7QVYXSjixmanPtPQL+weiTYbaB/wWX8JilB+Wllk4mxvP5w==",
+      "license": "MIT",
+      "dependencies": {
+        "ml-distance-euclidean": "^2.0.0"
       }
     },
     "node_modules/ms": {

--- a/backend/tourio/package.json
+++ b/backend/tourio/package.json
@@ -17,6 +17,7 @@
     "express": "^5.1.0",
     "firebase-admin": "^13.3.0",
     "leaflet": "^1.9.4",
+    "ml-knn": "^3.0.0",
     "ngrok": "^5.0.0-beta.2",
     "react-leaflet": "^5.0.0",
     "stripe": "^18.1.0"

--- a/backend/tourio/src/controllers/mlController.js
+++ b/backend/tourio/src/controllers/mlController.js
@@ -1,0 +1,10 @@
+const { predict } = require('../services/recommendationService');
+
+exports.getRecommendation = (req, res) => {
+  const { price, days } = req.body;
+  if (!price || !days) {
+    return res.status(400).json({ message: 'price and days are required' });
+  }
+  const label = predict(Number(price), Number(days));
+  res.json({ recommendedType: label });
+};

--- a/backend/tourio/src/routes/mlRoutes.js
+++ b/backend/tourio/src/routes/mlRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const { getRecommendation } = require('../controllers/mlController');
+
+router.post('/recommend', getRecommendation);
+
+module.exports = router;

--- a/backend/tourio/src/services/recommendationService.js
+++ b/backend/tourio/src/services/recommendationService.js
@@ -1,0 +1,30 @@
+const KNN = require('ml-knn');
+
+let knn;
+
+// Simple training dataset: [price, days] => class
+// class 0: budget tour, class 1: premium tour
+const features = [
+  [100, 2],
+  [150, 3],
+  [200, 3],
+  [350, 5],
+  [400, 6],
+  [800, 7],
+  [1200, 10]
+];
+const labels = [0, 0, 0, 1, 1, 1, 1];
+
+function trainModel() {
+  knn = new KNN(features, labels);
+}
+
+function predict(price, days) {
+  if (!knn) {
+    trainModel();
+  }
+  const result = knn.predict([[price, days]]);
+  return result[0] === 0 ? 'budget' : 'premium';
+}
+
+module.exports = { predict };


### PR DESCRIPTION
## Summary
- add `ml-knn` dependency to backend
- implement simple KNN-based recommendation service
- expose `/api/ml/recommend` endpoint

## Testing
- `npm install --ignore-scripts`


------
https://chatgpt.com/codex/tasks/task_b_68585add192483269583fbd3b51a14f2